### PR TITLE
HP-2667: Do not prevent exception when name is empty

### DIFF
--- a/src/FileStorage.php
+++ b/src/FileStorage.php
@@ -21,10 +21,11 @@ class FileStorage implements StorageInterface
 
     protected function getFullPath($name)
     {
-        if ($name === null || $name === '' || !is_string($name)) {
-            return null;
+        if (is_string($name) && $name !== '') {
+            return $this->path . '/' . $name[0] . '/' . $name;
         }
-        return $this->path . '/' . $name[0] . '/' . $name;
+
+        return null;
     }
 
     public function has($name)

--- a/src/FileStorage.php
+++ b/src/FileStorage.php
@@ -21,11 +21,18 @@ class FileStorage implements StorageInterface
 
     protected function getFullPath($name)
     {
+        if (empty($name)) {
+            return null;
+        }
         return $this->path . '/' . $name[0] . '/' . $name;
     }
 
     public function has($name)
     {
+        $path = $this->getFullPath($name);
+        if ($path === null) {
+            return false;
+        }
         return is_file($this->getFullPath($name));
     }
 
@@ -67,6 +74,10 @@ class FileStorage implements StorageInterface
     public function remove($name)
     {
         $path = $this->getFullPath($name);
+
+        if ($path === null) {
+            return true;
+        }
 
         return unlink($path);
     }

--- a/src/FileStorage.php
+++ b/src/FileStorage.php
@@ -21,7 +21,7 @@ class FileStorage implements StorageInterface
 
     protected function getFullPath($name)
     {
-        if (empty($name)) {
+        if ($name === null || $name === '' || !is_string($name)) {
             return null;
         }
         return $this->path . '/' . $name[0] . '/' . $name;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid file-path operations when non-string or empty names are supplied.
  * Existence checks and deletions now short-circuit for invalid/missing inputs to avoid errors.
  * Reduced redundant path computations for slightly improved reliability and efficiency.
  * No changes to public API signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->